### PR TITLE
Remove the default value for role_ids

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bullet_train-roles (0.1.2)
+    bullet_train-roles (0.1.3)
       active_hash
       activesupport
       cancancan

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Bullet Train Roles
 
-Bullet Train Roles provides a Yaml-based configuration layer on top of [CanCanCan](https://github.com/CanCanCommunity/cancancan). You can use this configuration file to simplify the definition of many common permissions, while still implementing more complicated permissions in CanCanCan's traditional `app/model/ability.rb`. 
+Bullet Train Roles provides a Yaml-based configuration layer on top of [CanCanCan](https://github.com/CanCanCommunity/cancancan). You can use this configuration file to simplify the definition of many common permissions, while still implementing more complicated permissions in CanCanCan's traditional `app/model/ability.rb`.
 
 Additionally, Bullet Train Roles makes it trivial to assign the same roles and associated permissions at different levels in your application. For example, you can assign someone administrative privileges at a team level, or only at a project level.
 
 Bullet Train Roles was created by [Andrew Culver](http://twitter.com/andrewculver) and [Adam Pallozzi](https://twitter.com/adampallozzi).
 
-## Example Domain Model 
+## Example Domain Model
 
 For the sake of this document, we're going to assume the following example modeling around users and teams:
 
@@ -15,7 +15,7 @@ For the sake of this document, we're going to assume the following example model
 - A `Membership` can have zero, one, or many `Role`s assigned.
 - A `Membership` without a `Role` is just a default team member.
 
-You don't have to name your models the same thing in order to use this Ruby Gem, but it does depend on having a similar structure. 
+You don't have to name your models the same thing in order to use this Ruby Gem, but it does depend on having a similar structure.
 
 > If you're interested in reading more about how and why Bullet Train implements this structure, you can [read about it on our blog](https://blog.bullettrain.co/teams-should-be-an-mvp-feature/).
 
@@ -51,10 +51,6 @@ The installer will:
  - add `include Role::Support` to `app/models/membership.rb`.
  - add a basic `permit` call in `app/models/ability.rb`.
 
-
-### Limitations
-
-The generators currently assume you're using PostgreSQL and `jsonb` will be available when generating a `role_ids` column. If you're using MySQL, the generator will use `json` instead, although you won't be able to set a default value and you'll need to take care of this in the model.
 
 ## Usage
 

--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,7 @@ bundle install
 # We need to cd into the dummy app because it uses a different Rakefile
 cd test/dummy
 bundle install
-rake db:test:prepare
+rake db:reset
 cd ../..
 
 # Do any other automated setup that you need to do here

--- a/lib/generators/bullet_train/roles/install/install_generator.rb
+++ b/lib/generators/bullet_train/roles/install/install_generator.rb
@@ -58,11 +58,6 @@ module BulletTrain
         adapter_name
       end
 
-      def db_adapter_supports_defaults?
-        supported_db_adapters = %w[postgresql]
-        supported_db_adapters.include?(db_adapter)
-      end
-
       def find_json_data_type_identifier
         adapter_name = db_adapter
 
@@ -95,14 +90,6 @@ module BulletTrain
         File.write(file_location, update_file_content.join)
       end
 
-      def add_default_value_to_migration(file_name, table_name)
-        file_location = Dir["db/migrate/*_#{file_name}.rb"].last
-        line_to_match = "add_column :#{table_name.downcase}, :role_ids"
-        content_to_add = ", default: []\n"
-
-        add_in_file(file_location, line_to_match, content_to_add)
-      end
-
       def migration_file_exists?(file_name)
         file_location = Dir["db/migrate/*_#{file_name}.rb"].last
 
@@ -123,8 +110,6 @@ module BulletTrain
         puts("Generating migration to add role_ids to #{top_level_model}")
 
         generate "migration", "#{migration_file_name} role_ids:#{json_data_type_identifier}"
-
-        add_default_value_to_migration(migration_file_name, top_level_model_table_name) if db_adapter_supports_defaults?
 
         puts("Success 🎉🎉\n\n")
       end

--- a/lib/models/role.rb
+++ b/lib/models/role.rb
@@ -109,23 +109,21 @@ class Role < ActiveYaml::Base
   class Collection < Array
     def initialize(model, ary)
       @model = model
-
       super(ary)
     end
 
     def <<(role)
       return true if include?(role)
-
-      role_ids = @model.role_ids
-
+      role_ids = @model.role_ids || []
       role_ids << role.id
-
       @model.update(role_ids: role_ids)
     end
 
     def delete(role)
-      @model.role_ids -= [role.key]
-
+      return @model.save unless include?(role)
+      current_role_ids = @model.role_ids || []
+      new_role_ids = current_role_ids - [role.key]
+      @model.role_ids = new_role_ids
       @model.save
     end
   end

--- a/lib/roles/support.rb
+++ b/lib/roles/support.rb
@@ -44,7 +44,7 @@ module Roles
       after_destroy :invalidate_cache
 
       def validate_roles
-        self.role_ids = role_ids.select(&:present?)
+        self.role_ids = role_ids&.select(&:present?) || []
 
         return if @allowed_roles.nil?
 
@@ -66,7 +66,7 @@ module Roles
       end
 
       def roles_without_defaults
-        role_ids.map { |role_id| Role.find(role_id) }
+        role_ids&.map { |role_id| Role.find(role_id) } || []
       end
 
       def manageable_roles

--- a/test/dummy/db/migrate/20220103095034_create_memberships.rb
+++ b/test/dummy/db/migrate/20220103095034_create_memberships.rb
@@ -1,7 +1,9 @@
 class CreateMemberships < ActiveRecord::Migration[7.0]
   def change
     create_table :memberships do |t|
-      t.jsonb :role_ids, default: []
+      # We deliberately _don't_ set a default here because it's not possible to set a default with mysql.
+      # To make the gem compatible with more db_adapters out of the box, we should only use features that are available in all databases
+      t.jsonb :role_ids
       t.references :user, null: false, foreign_key: true
       t.references :team, null: false, foreign_key: true
 

--- a/test/dummy/db/migrate/20220103181617_create_scaffolding_absolutely_abstract_creative_concepts_collaborators.rb
+++ b/test/dummy/db/migrate/20220103181617_create_scaffolding_absolutely_abstract_creative_concepts_collaborators.rb
@@ -1,7 +1,7 @@
 class CreateScaffoldingAbsolutelyAbstractCreativeConceptsCollaborators < ActiveRecord::Migration[7.0]
   def change
     create_table :scaffolding_absolutely_abstract_creative_concepts_collaborators do |t|
-      t.jsonb :role_ids, default: []
+      t.jsonb :role_ids
       t.references :creative_concept, null: false, foreign_key: {to_table: "scaffolding_absolutely_abstract_creative_concepts"}, index: {name: "index_creative_concepts_collaborators_on_creative_concept_id"}
       t.references :membership, null: false, index: {name: "index_creative_concepts_collaborators_on_membership_id"}
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 2022_01_03_181617) do
   enable_extension "plpgsql"
 
   create_table "memberships", force: :cascade do |t|
-    t.jsonb "role_ids", default: []
+    t.jsonb "role_ids"
     t.bigint "user_id", null: false
     t.bigint "team_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2022_01_03_181617) do
   end
 
   create_table "scaffolding_absolutely_abstract_creative_concepts_collaborators", force: :cascade do |t|
-    t.jsonb "role_ids", default: []
+    t.jsonb "role_ids"
     t.bigint "creative_concept_id", null: false
     t.bigint "membership_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
* mysql won't allow a default value.  Rather than require mysql users to add custom code to their application
  to make it work, this change updates the gem to allow for nil values in the role_id column.
  As a result, there is now no need to set a default value for any database.