### PR TITLE
Avoid repeated parent_id lookups that hit the active record cache

### DIFF
--- a/lib/roles/user.rb
+++ b/lib/roles/user.rb
@@ -9,12 +9,16 @@ module Roles
     included do
       def parent_ids_for(role, through, parent)
         parent_id_column = "#{parent}_id"
-        # key = "#{role.key}_#{through}_#{parent_id_column}s"
+        key = "#{role.key}_#{through}_#{parent_id_column}s"
+
+        @parent_id_cache ||= {}
+        return @parent_id_cache[key] if @parent_id_cache[key]
+
         # TODO Maybe we should make ability caching a default feature of the gem?
         # If we do that, we would just make it check whether `ability_cache` exists.
         # return ability_cache[key] if ability_cache && ability_cache[key]
         role = nil if role.default?
-        send(through).with_role(role).distinct.pluck(parent_id_column)
+        @parent_id_cache[key] = send(through).with_role(role).distinct.pluck(parent_id_column)
         # TODO Maybe we should make ability caching a default feature of the gem?
         # current_cache = ability_cache || {}
         # current_cache[key] = value

--- a/lib/roles/user.rb
+++ b/lib/roles/user.rb
@@ -11,14 +11,14 @@ module Roles
         parent_id_column = "#{parent}_id"
         key = "#{role.key}_#{through}_#{parent_id_column}s"
 
-        @parent_id_cache ||= {}
-        return @parent_id_cache[key] if @parent_id_cache[key]
+        @_parent_ids_for_cache ||= {}
+        return @_parent_ids_for_cache[key] if @_parent_ids_for_cache[key]
 
         # TODO Maybe we should make ability caching a default feature of the gem?
         # If we do that, we would just make it check whether `ability_cache` exists.
         # return ability_cache[key] if ability_cache && ability_cache[key]
         role = nil if role.default?
-        @parent_id_cache[key] = send(through).with_role(role).distinct.pluck(parent_id_column)
+        @_parent_ids_for_cache[key] = send(through).with_role(role).distinct.pluck(parent_id_column)
         # TODO Maybe we should make ability caching a default feature of the gem?
         # current_cache = ability_cache || {}
         # current_cache[key] = value


### PR DESCRIPTION
With large `roles.yml` files a single request can hit `#parent_ids_for` many times, which is returned from the active record cache rather than the database, but this can still be a significant performance hit.

This change means each query is only run once per request and memoized.