### PR TITLE
Save permissions structure to Rails.cache if a cache key is passed

### DIFF
--- a/lib/roles/permit.rb
+++ b/lib/roles/permit.rb
@@ -24,7 +24,7 @@ module Roles
           if permission.is_debug
             puts permission.info
           else
-            puts  "can #{permission.actions}, #{permission.model}, #{permission.condition}"
+            puts "can #{permission.actions}, #{permission.model}, #{permission.condition}"
           end
         end
         puts "############################"
@@ -55,10 +55,10 @@ module Roles
     def add_abilities_for(role, user, through, parent, intermediary)
       permissions = []
       role.ability_generator(user, through, parent, intermediary) do |ag|
-        if ag.valid?
-          permissions << OpenStruct.new(is_debug: false, actions: ag.actions, model: ag.model.to_s, condition: ag.condition)
+        permissions << if ag.valid?
+          OpenStruct.new(is_debug: false, actions: ag.actions, model: ag.model.to_s, condition: ag.condition)
         else
-          permissions << OpenStruct.new(is_debug: true, info: "# #{ag.model} does not respond to #{parent} so we're not going to add an ability for the #{through} context")
+          OpenStruct.new(is_debug: true, info: "# #{ag.model} does not respond to #{parent} so we're not going to add an ability for the #{through} context")
         end
       end
       permissions

--- a/lib/roles/permit.rb
+++ b/lib/roles/permit.rb
@@ -2,45 +2,67 @@
 
 module Roles
   module Permit
-    def permit(user, through:, parent:, debug: false, intermediary: nil)
+    def permit(user, through:, parent:, debug: false, intermediary: nil, cache_key: nil)
       # When changing permissions during development, you may also want to do this on each request:
       # User.update_all ability_cache: nil if Rails.env.development?
-      output = []
-      added_roles = Set.new
-      user.send(through).map(&:roles).flatten.uniq.each do |role|
-        unless added_roles.include?(role)
-          output << "########### ROLE: #{role.key}"
-          output += add_abilities_for(role, user, through, parent, intermediary)
-          added_roles << role
+      permissions = if cache_key
+        Rails.cache.fetch(cache_key) do
+          build_permissions(user, through, parent, intermediary)
         end
+      else
+        build_permissions(user, through, parent, intermediary)
+      end
 
-        role.included_roles.each do |included_role|
-          unless added_roles.include?(included_role)
-            output << "############# INCLUDED ROLE: #{included_role.key}"
-            output += add_abilities_for(included_role, user, through, parent, intermediary)
-          end
-        end
+      permissions.each do |permission|
+        can(permission[1], permission[2].constantize, permission[3]) if permission[0]
       end
 
       if debug
         puts "###########################"
         puts "Auto generated `ability.rb` content:"
-        puts output
+        permissions.map do |permission|
+          if permission[0]
+            puts  "can #{permission[1]}, #{permission[2]}, #{permission[3]}"
+          else
+            puts permission[1]
+          end
+        end
         puts "############################"
       end
     end
 
-    def add_abilities_for(role, user, through, parent, intermediary)
-      output = []
-      role.ability_generator(user, through, parent, intermediary) do |ag|
-        if ag.valid?
-          output << "can #{ag.actions}, #{ag.model}, #{ag.condition}"
-          can(ag.actions, ag.model, ag.condition)
-        else
-          output << "# #{ag.model} does not respond to #{parent} so we're not going to add an ability for the #{through} context"
+    def build_permissions(user, through, parent, intermediary)
+      added_roles = Set.new
+      permissions = []
+      user.send(through).map(&:roles).flatten.uniq.each do |role|
+        unless added_roles.include?(role)
+          permissions << [false, "########### ROLE: #{role.key}"]
+          permissions += add_abilities_for(role, user, through, parent, intermediary)
+          added_roles << role
+        end
+
+        role.included_roles.each do |included_role|
+          unless added_roles.include?(included_role)
+            permissions << [false, "############# INCLUDED ROLE: #{included_role.key}"]
+            permissions += add_abilities_for(included_role, user, through, parent, intermediary)
+          end
         end
       end
-      output
+
+      permissions
+    end
+
+    def add_abilities_for(role, user, through, parent, intermediary)
+      output = []
+      permissions = []
+      role.ability_generator(user, through, parent, intermediary) do |ag|
+        if ag.valid?
+          permissions << [true, ag.actions, ag.model.to_s, ag.condition]
+        else
+          permissions << [false, "# #{ag.model} does not respond to #{parent} so we're not going to add an ability for the #{through} context"]
+        end
+      end
+      permissions
     end
   end
 end


### PR DESCRIPTION
With a large roles.yml, even if you are using a `UserPermissionCachingDecorator` to intercept db access (or using #20), the calls to `permit` can be pretty slow. 

In an app with ~200 entries in the roles.yml it was taking ~130ms to process all the permit calls.

This change allows a `cache_key` parameter to be passed in, and if it is, the structure that is passed to CanCanCan is cached by rails, saving most of the processing time.

Note this should not be a replacement for #20 - which is caching at a different level and should also be implemented.